### PR TITLE
feat: メモリ計測・起動時間計測・権限警告サマリーを実装 (#53 #54 #55)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -304,6 +304,10 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     bench_test_mod.addImport("scanner", scanner_parallel_mod);
+    const args_bench_mod = b.createModule(.{
+        .root_source_file = b.path("src/utils/args.zig"),
+    });
+    bench_test_mod.addImport("args", args_bench_mod);
     const bench_tests = b.addTest(.{ .root_module = bench_test_mod });
     const run_bench_tests = b.addRunArtifact(bench_tests);
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -138,6 +138,17 @@ pub fn main() !void {
     });
     const elapsed_ms = std.time.milliTimestamp() - start_ms;
 
+    // 権限エラーサマリーを stderr に出力
+    if (result.perm_errors > 0) {
+        std.debug.print(
+            "sz: {d} {s} could not be accessed (permission denied)\n",
+            .{
+                result.perm_errors,
+                if (result.perm_errors == 1) "directory" else "directories",
+            },
+        );
+    }
+
     // 現在時刻 (--older フィルタ用)
     const now_sec: i64 = @divTrunc(std.time.milliTimestamp(), 1000);
 

--- a/src/scanner/parallel.zig
+++ b/src/scanner/parallel.zig
@@ -158,6 +158,7 @@ pub fn scan(
 
     // DirEntry ツリーを構築
     const root_entry = try buildDirEntry(allocator, root_node);
+    const perm_errors = ctx.perm_errors.load(.monotonic);
 
     // ScanNode ツリーを解放
     freeScanNodes(allocator, root_node);
@@ -165,7 +166,7 @@ pub fn scan(
     allocator.free(root_node.name);
     allocator.destroy(root_node);
 
-    return types.ScanResult{ .root = root_entry };
+    return types.ScanResult{ .root = root_entry, .perm_errors = perm_errors };
 }
 
 // ─── tests ───────────────────────────────────────────────────────────────────
@@ -334,4 +335,30 @@ test "scan: permission denied directory is skipped" {
 
     try std.testing.expectEqual(@as(u32, 1), result.root.file_count);
     try std.testing.expectEqual(@as(u64, 2), result.root.total_size);
+}
+
+test "scan: perm_errors incremented for permission denied directory" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    {
+        const f = try tmp.dir.createFile("visible.txt", .{});
+        defer f.close();
+        try f.writeAll("ok");
+    }
+    try tmp.dir.makeDir("noaccess");
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = try tmp.dir.realpath("noaccess", &path_buf);
+    try std.posix.fchmodat(std.posix.AT.FDCWD, dir_path, 0o000, 0);
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const root_path = try tmp.dir.realpath(".", &path_buf);
+    const result = try scan(arena.allocator(), root_path, .{ .apparent = true });
+
+    try std.posix.fchmodat(std.posix.AT.FDCWD, dir_path, 0o755, 0);
+
+    try std.testing.expectEqual(@as(u32, 1), result.perm_errors);
 }

--- a/src/scanner/posix.zig
+++ b/src/scanner/posix.zig
@@ -44,6 +44,7 @@ fn scanDirRecursive(
     root_dev: posix.dev_t,
     options: ScanOptions,
     visited: *std.AutoHashMap(InodeKey, void),
+    perm_errors: *u32,
 ) !types.DirEntry {
     var total_size: u64 = 0;
     var file_count: u32 = 0;
@@ -108,7 +109,7 @@ fn scanDirRecursive(
 
                         dir_count += 1;
                         const next_depth: u8 = if (depth < 255) depth + 1 else 255;
-                        const child = try scanDirRecursive(allocator, child_dir, entry.name, next_depth, root_dev, options, visited);
+                        const child = try scanDirRecursive(allocator, child_dir, entry.name, next_depth, root_dev, options, visited, perm_errors);
                         total_size += child.total_size;
                         file_count += child.file_count;
                         dir_count += child.dir_count;
@@ -130,6 +131,7 @@ fn scanDirRecursive(
                             .{entry.name},
                         ) catch "sz: warning: permission denied\n";
                         std.fs.File.stderr().writeAll(warn_msg) catch {};
+                        perm_errors.* += 1;
                         continue;
                     },
                     else => continue,
@@ -144,7 +146,7 @@ fn scanDirRecursive(
 
                 dir_count += 1;
                 const next_depth: u8 = if (depth < 255) depth + 1 else 255;
-                const child = try scanDirRecursive(allocator, child_dir, entry.name, next_depth, root_dev, options, visited);
+                const child = try scanDirRecursive(allocator, child_dir, entry.name, next_depth, root_dev, options, visited, perm_errors);
                 total_size += child.total_size;
                 file_count += child.file_count;
                 dir_count += child.dir_count;
@@ -203,6 +205,7 @@ pub fn scan(
     defer visited.deinit();
     try visited.put(inodeKey(root_stat.dev, root_stat.ino), {});
 
+    var perm_errors: u32 = 0;
     const root = try scanDirRecursive(
         allocator,
         root_dir,
@@ -211,9 +214,10 @@ pub fn scan(
         root_dev,
         options,
         &visited,
+        &perm_errors,
     );
 
-    return types.ScanResult{ .root = root };
+    return types.ScanResult{ .root = root, .perm_errors = perm_errors };
 }
 
 // ─── tests ───────────────────────────────────────────────────────────────────

--- a/src/scanner/types.zig
+++ b/src/scanner/types.zig
@@ -25,6 +25,8 @@ pub const DirEntry = struct {
 /// メモリ管理は呼び出し側の ArenaAllocator で行う（arena.deinit() で一括解放）。
 pub const ScanResult = struct {
     root: DirEntry,
+    /// 権限エラー（EACCES/EPERM）が発生したディレクトリの数。
+    perm_errors: u32 = 0,
 };
 
 test "DirEntry nameSlice" {

--- a/src/scanner/worker.zig
+++ b/src/scanner/worker.zig
@@ -55,6 +55,8 @@ pub const WorkerContext = struct {
     cross_mount: bool,
     /// true = ファイルサイズ(st_size)を使用、false = ディスク使用量(st_blocks × 512)
     apparent: bool = false,
+    /// 権限エラー発生ディレクトリ数 (atomic: 複数スレッドから加算)
+    perm_errors: std.atomic.Value(u32) = .{ .raw = 0 },
 };
 
 fn getDeviceId(dir: std.fs.Dir) !posix.dev_t {
@@ -101,7 +103,21 @@ fn processDir(ctx: *WorkerContext, item: queue_mod.WorkItem) !void {
     var dir = std.fs.openDirAbsolute(item.path, .{
         .iterate = true,
         .no_follow = true,
-    }) catch return;
+    }) catch |err| switch (err) {
+        error.AccessDenied => {
+            var warn_buf: [512]u8 = undefined;
+            const name = std.fs.path.basename(item.path);
+            const warn_msg = std.fmt.bufPrint(
+                &warn_buf,
+                "sz: warning: cannot access '{s}': permission denied\n",
+                .{name},
+            ) catch "sz: warning: permission denied\n";
+            std.fs.File.stderr().writeAll(warn_msg) catch {};
+            _ = ctx.perm_errors.fetchAdd(1, .monotonic);
+            return;
+        },
+        else => return,
+    };
     defer dir.close();
 
     const dir_dev = getDeviceId(dir) catch return;

--- a/tests/bench_test.zig
+++ b/tests/bench_test.zig
@@ -13,6 +13,76 @@
 ///     'gdu /path/to/large'
 const std = @import("std");
 const scanner = @import("scanner");
+const args_mod = @import("args");
+
+// ─── CountingAllocator: メモリ使用量計測用 ────────────────────────────────────
+//
+// スキャン中に要求されたバイト数のピーク値を計測する。
+// mutex 保護により複数ワーカースレッドからの同時アクセスに対応。
+
+const CountingAllocator = struct {
+    inner: std.mem.Allocator,
+    mutex: std.Thread.Mutex = .{},
+    current: usize = 0,
+    peak: usize = 0,
+
+    pub fn allocator(self: *CountingAllocator) std.mem.Allocator {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    const vtable = std.mem.Allocator.VTable{
+        .alloc = alloc,
+        .resize = resize,
+        .remap = remap,
+        .free = free,
+    };
+
+    fn alloc(ctx: *anyopaque, n: usize, al: std.mem.Alignment, ra: usize) ?[*]u8 {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const res = self.inner.rawAlloc(n, al, ra) orelse return null;
+        self.current += n;
+        if (self.current > self.peak) self.peak = self.current;
+        return res;
+    }
+
+    fn resize(ctx: *anyopaque, buf: []u8, al: std.mem.Alignment, nl: usize, ra: usize) bool {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (!self.inner.rawResize(buf, al, nl, ra)) return false;
+        if (nl > buf.len) {
+            self.current += nl - buf.len;
+            if (self.current > self.peak) self.peak = self.current;
+        } else if (nl < buf.len) {
+            self.current -= buf.len - nl;
+        }
+        return true;
+    }
+
+    fn remap(ctx: *anyopaque, buf: []u8, al: std.mem.Alignment, nl: usize, ra: usize) ?[*]u8 {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const res = self.inner.rawRemap(buf, al, nl, ra) orelse return null;
+        if (nl > buf.len) {
+            self.current += nl - buf.len;
+            if (self.current > self.peak) self.peak = self.current;
+        } else if (nl < buf.len) {
+            self.current -= buf.len - nl;
+        }
+        return res;
+    }
+
+    fn free(ctx: *anyopaque, buf: []u8, al: std.mem.Alignment, ra: usize) void {
+        const self: *CountingAllocator = @ptrCast(@alignCast(ctx));
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        self.inner.rawFree(buf, al, ra);
+        self.current -= @min(self.current, buf.len);
+    }
+};
 
 /// テスト用一時ディレクトリに `file_count` 個のファイルを生成する。
 /// 生成したルートパスを返す（呼び出し側で removeTree すること）。
@@ -83,4 +153,85 @@ test "bench: 50k files scan completes within 1000ms" {
 
     try std.testing.expect(result.root.file_count >= file_count);
     try std.testing.expect(elapsed < limit_ms);
+}
+
+// ─── Issue X-4: メモリ使用量計測 ─────────────────────────────────────────────
+//
+// 目標: 100万ファイル (= 10万ディレクトリ × 10ファイル) で < 50MB
+// 換算: ディレクトリあたり 500 bytes 以内
+// テスト: 100 dirs × 10 files で < 50KB (同比率でスケール)
+
+test "bench: memory usage within 500-bytes-per-dir budget (extrapolates to <50MB at 100k dirs)" {
+    const dir_count: u32 = 100;
+    const files_per_dir: u32 = 10;
+    // 50MB / 100_000 dirs × 100 dirs = 50KB
+    const budget_bytes: usize = 50_000;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // ディレクトリとファイルを作成（setup 用に別アロケータを使用）
+    var setup_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer setup_arena.deinit();
+
+    var i: u32 = 0;
+    while (i < dir_count) : (i += 1) {
+        var dir_name_buf: [32]u8 = undefined;
+        const dir_name = try std.fmt.bufPrint(&dir_name_buf, "dir{d:0>4}", .{i});
+        try tmp.dir.makeDir(dir_name);
+        var sub = try tmp.dir.openDir(dir_name, .{});
+        defer sub.close();
+        var j: u32 = 0;
+        while (j < files_per_dir) : (j += 1) {
+            var file_name_buf: [32]u8 = undefined;
+            const file_name = try std.fmt.bufPrint(&file_name_buf, "f{d:0>4}.bin", .{j});
+            const f = try sub.createFile(file_name, .{});
+            f.close();
+        }
+    }
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root_path = try tmp.dir.realpath(".", &path_buf);
+
+    // CountingAllocator でスキャン (page_allocator はスレッドセーフ)
+    var counter = CountingAllocator{ .inner = std.heap.page_allocator };
+    const result = try scanner.scan(counter.allocator(), root_path, .{});
+    const peak = counter.peak;
+
+    std.debug.print(
+        "\n[bench:memory] {d} dirs, {d} files: peak {d} bytes, budget {d} bytes ({d} bytes/dir)\n",
+        .{ result.root.dir_count, result.root.file_count, peak, budget_bytes, if (result.root.dir_count > 0) peak / result.root.dir_count else 0 },
+    );
+
+    try std.testing.expect(result.root.dir_count >= dir_count);
+    try std.testing.expect(peak < budget_bytes);
+}
+
+// ─── Issue X-5: 起動時間計測 ─────────────────────────────────────────────────
+//
+// 目標: スキャン開始まで (= 引数パース完了まで) < 5ms
+// 引数パースは parseSlice() を直接計測する
+
+test "bench: argument parsing completes within 5ms" {
+    const limit_ns: i64 = 5_000_000; // 5ms
+
+    const t0 = std.time.nanoTimestamp();
+    const parsed = try args_mod.parseSlice(&.{
+        "--depth",    "3",
+        "--top",      "10",
+        "--jobs",     "4",
+        "/some/path",
+    });
+    const elapsed_ns = std.time.nanoTimestamp() - t0;
+
+    std.debug.print(
+        "\n[bench:startup] arg parse: {d} ns (limit {d} ns)\n",
+        .{ elapsed_ns, limit_ns },
+    );
+
+    // 引数が正しくパースされていることを確認
+    try std.testing.expectEqual(@as(u32, 3), parsed.depth);
+    try std.testing.expectEqual(@as(u32, 10), parsed.top);
+    try std.testing.expectEqual(@as(?u32, 4), parsed.jobs);
+    try std.testing.expect(elapsed_ns < limit_ns);
 }

--- a/tests/scanner_test.zig
+++ b/tests/scanner_test.zig
@@ -241,3 +241,31 @@ test "fixture: large_dir - 11 files" {
     try std.testing.expectEqual(@as(u32, 11), result.root.file_count);
     try std.testing.expectEqual(@as(u64, 660), result.root.total_size);
 }
+
+// ─── Issue #55: stderr 権限警告出力 ───────────────────────────────────────────
+
+test "scan: perm_errors count tracks number of denied directories" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makeDir("denied1");
+    try tmp.dir.makeDir("denied2");
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    var path_buf2: [std.fs.max_path_bytes]u8 = undefined;
+    const d1 = try tmp.dir.realpath("denied1", &path_buf);
+    try std.posix.fchmodat(std.posix.AT.FDCWD, d1, 0o000, 0);
+    const d2 = try tmp.dir.realpath("denied2", &path_buf2);
+    try std.posix.fchmodat(std.posix.AT.FDCWD, d2, 0o000, 0);
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const root_path = try tmp.dir.realpath(".", &path_buf);
+    const result = try scanner.scan(arena.allocator(), root_path, .{});
+
+    try std.posix.fchmodat(std.posix.AT.FDCWD, d1, 0o755, 0);
+    try std.posix.fchmodat(std.posix.AT.FDCWD, d2, 0o755, 0);
+
+    try std.testing.expectEqual(@as(u32, 2), result.perm_errors);
+}


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## Issues No
close #53
close #54
close #55

## 概要
メモリ使用量計測 (X-4)、起動時間計測 (X-5)、stderr 権限警告件数サマリー出力 (X-6) を実装。TDD（Red → Green）で開発。

## 変更内容
### 追加機能
- [x] Issue #53: `CountingAllocator` によるメモリ使用量計測テスト（100 dirs × 10 files でピーク 30KB、予算 50KB 以内）
- [x] Issue #54: `parseSlice()` 実行時間計測テスト（3μs、目標 5ms 以内）
- [x] Issue #55: `ScanResult.perm_errors` フィールド追加 — 権限拒否ディレクトリ数を返す
- [x] Issue #55: スキャン完了後に `sz: N directories could not be accessed` を stderr に出力

### その他の変更
- [x] テスト追加（`bench_test.zig` / `scanner_test.zig` / `parallel.zig`）

## 動作確認手順

1. 確認手順
   - [x] `zig build` でビルドが通ることを確認
   - [x] `zig build test` でテストが通ることを確認
   - [x] `zig build bench` でベンチマークが通ることを確認

## テスト

- [x] 単体テストを追加・更新しました
- [x] 手動テストを実施しました

### テスト実行結果

```
zig build test   → EXIT:0
zig build bench  → EXIT:0

[bench:memory] 100 dirs, 1000 files: peak 30416 bytes, budget 50000 bytes (304 bytes/dir)
[bench:startup] arg parse: 3000 ns (limit 5000000 ns)
```

## 品質チェック
- [x] `zig fmt` でコード整形を実行
- [x] 不要なコメントやデバッグコードを削除

## 破壊的変更
- `ScanResult` 構造体に `perm_errors: u32 = 0` フィールドを追加（デフォルト値あり・後方互換）
- `posix.zig` の内部関数 `scanDirRecursive` にパラメータ追加（公開 API は `scan()` のみで変更なし）